### PR TITLE
CWS-26: Add /items endpoint to API with GET and POST handlers

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -16,6 +16,7 @@ func main() {
 	router := gin.Default()
 	router.GET("/", index)
 	router.GET("/items", getItems)
+	router.POST("/items", addItem)
 
 	router.Run("0.0.0.0:8080")
 }
@@ -28,4 +29,21 @@ func index(c *gin.Context) {
 
 func getItems(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, items)
+}
+
+func addItem(c *gin.Context) {
+	var newItem model.Item
+
+	if err := c.BindJSON(&newItem); err != nil {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid request"})
+		return
+	}
+
+	if newItem.Title == "" || newItem.Price <= 0 {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid item data"})
+		return
+	}
+
+	items = append(items, newItem)
+	c.IndentedJSON(http.StatusCreated, newItem)
 }

--- a/api/main.go
+++ b/api/main.go
@@ -10,7 +10,7 @@ func main() {
 	router := gin.Default()
 	router.GET("/", index)
 
-	router.Run("localhost:8080")
+	router.Run("0.0.0.0:8080")
 }
 
 func index(c *gin.Context) {

--- a/api/main.go
+++ b/api/main.go
@@ -1,14 +1,21 @@
 package main
 
 import (
+	"github.com/gin-gonic/gin"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
+	"charlie-will-software/shop-tui/api/model"
 )
+
+var items = []model.Item{
+	{Id: 1, Title: "Bread", Price: 1.09},
+	{Id: 2, Title: "Milk", Price: 1.5},
+}
 
 func main() {
 	router := gin.Default()
 	router.GET("/", index)
+	router.GET("/items", getItems)
 
 	router.Run("0.0.0.0:8080")
 }
@@ -17,4 +24,8 @@ func index(c *gin.Context) {
 	jsonData := []byte(`{"msg": "Hello world!"}`)
 
 	c.Data(http.StatusOK, "application/json", jsonData)
+}
+
+func getItems(c *gin.Context) {
+	c.IndentedJSON(http.StatusOK, items)
 }

--- a/api/main.go
+++ b/api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/gin-gonic/gin"
 	"net/http"
+	"strconv"
 
 	"charlie-will-software/shop-tui/api/model"
 )
@@ -16,6 +17,7 @@ func main() {
 	router := gin.Default()
 	router.GET("/", index)
 	router.GET("/items", getItems)
+	router.GET("/items/:id", getItemById)
 	router.POST("/items", addItem)
 
 	router.Run("0.0.0.0:8080")
@@ -29,6 +31,25 @@ func index(c *gin.Context) {
 
 func getItems(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, items)
+}
+
+func getItemById(c *gin.Context) {
+	id := c.Param("id")
+	idInt, err := strconv.Atoi(id)
+	if err != nil {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "invalid item ID"})
+		return
+	}
+
+	// Find an Item with the correct Id.
+	for _, a := range items {
+		if a.Id == idInt {
+			c.IndentedJSON(http.StatusOK, a)
+			return
+		}
+	}
+
+	c.IndentedJSON(http.StatusNotFound, gin.H{"message": "item not found"})
 }
 
 func addItem(c *gin.Context) {

--- a/api/main.go
+++ b/api/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"os"
 	"strconv"
 	"sync"
 
@@ -21,12 +22,21 @@ var (
 
 func main() {
 	router := gin.Default()
+
 	router.GET("/", index)
 	router.GET("/items", getItems)
 	router.GET("/items/:id", getItemById)
 	router.POST("/items", addItem)
 
-	router.Run("0.0.0.0:8080")
+	address := getEnv("SERVER_ADDRESS", "0.0.0.0:8080")
+	router.Run(address)
+}
+
+func getEnv(key, defaultValue string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultValue
 }
 
 func index(c *gin.Context) {

--- a/api/main.go
+++ b/api/main.go
@@ -1,17 +1,23 @@
 package main
 
 import (
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"strconv"
+	"sync"
+
+	"github.com/gin-gonic/gin"
 
 	"charlie-will-software/shop-tui/api/model"
 )
 
-var items = []model.Item{
-	{Id: 1, Title: "Bread", Price: 1.09},
-	{Id: 2, Title: "Milk", Price: 1.5},
-}
+// Seed the items array with data
+var (
+	items = []model.Item{
+		{Id: 1, Title: "Bread", Price: 1.09},
+		{Id: 2, Title: "Milk", Price: 1.5},
+	}
+	mu sync.Mutex
+)
 
 func main() {
 	router := gin.Default()
@@ -30,6 +36,8 @@ func index(c *gin.Context) {
 }
 
 func getItems(c *gin.Context) {
+	mu.Lock()
+	defer mu.Unlock()
 	c.IndentedJSON(http.StatusOK, items)
 }
 
@@ -41,6 +49,8 @@ func getItemById(c *gin.Context) {
 		return
 	}
 
+	mu.Lock()
+	defer mu.Unlock()
 	// Find an Item with the correct Id.
 	for _, a := range items {
 		if a.Id == idInt {
@@ -65,6 +75,8 @@ func addItem(c *gin.Context) {
 		return
 	}
 
+	mu.Lock()
 	items = append(items, newItem)
+	mu.Unlock()
 	c.IndentedJSON(http.StatusCreated, newItem)
 }

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -1,0 +1,7 @@
+package model
+
+type Item struct {
+	Id    int     `json:"id"`
+	Title string  `json:"title"`
+	Price float32 `json:"price"`
+}


### PR DESCRIPTION
This PR adds a model for inventory items, 3 new API endpoints, and environment variable support for the server address configuration.

Through development, I forgot the original plan to use `/inventory` and used `/items`. Upon reflection, I've decided to stay with this as naming the endpoint path after the object being accessed is a common approach for RESTful APIs.

## Endpoints
- GET `/items`
  Returns a list of all inventory items.
- GET `/items/<id>`
  Returns just the item with the ID given in the request path.
  Returns an error if there are no items with the ID.
- POST `/items`
  Takes a JSON object with the fields for a new item and adds it to the items array.
  Performs validation on the input data.