### PR TITLE
API update (patch) endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -6,3 +6,10 @@
 go get .
 go run .
 ```
+## Bruno collection
+
+The directory `bruno-collection/` contains example HTTP requests that can be made to the API, using the [Bruno API Client](https://www.usebruno.com/). This allows for easy testing of the endpoints.
+
+To use the collection, download, install, and open Bruno. Select `Collection -> Open Collection` at the top and open the `bruno-collection/` directory. You can send and modify the available example requests.
+
+You will need a running instance of the application. The collection has a default environment file, which can be selected in the top-right. This sets the address of the test instance to localhost:8080. You can click "Configure" to change this.

--- a/api/bruno-collection/Items/Add item.bru
+++ b/api/bruno-collection/Items/Add item.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Add item
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{base_url}}/items
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "id": 3,
+    "title": "Apple",
+    "price": 0.15
+  }
+}

--- a/api/bruno-collection/Items/Delete item.bru
+++ b/api/bruno-collection/Items/Delete item.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Delete item
+  type: http
+  seq: 4
+}
+
+delete {
+  url: {{base_url}}/items/2
+  body: none
+  auth: none
+}

--- a/api/bruno-collection/Items/Get item by ID.bru
+++ b/api/bruno-collection/Items/Get item by ID.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get item by ID
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{base_url}}/items/1
+  body: none
+  auth: none
+}

--- a/api/bruno-collection/Items/Get items.bru
+++ b/api/bruno-collection/Items/Get items.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get items
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{base_url}}/items
+  body: none
+  auth: none
+}

--- a/api/bruno-collection/Items/Update item.bru
+++ b/api/bruno-collection/Items/Update item.bru
@@ -1,0 +1,18 @@
+meta {
+  name: Update item
+  type: http
+  seq: 5
+}
+
+patch {
+  url: {{base_url}}/items/1
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "title": "New Bread",
+    "price": 1.99
+  }
+}

--- a/api/bruno-collection/bruno.json
+++ b/api/bruno-collection/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "Shop-TUI",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/api/bruno-collection/environments/shop-tui.bru
+++ b/api/bruno-collection/environments/shop-tui.bru
@@ -1,0 +1,3 @@
+vars {
+  base_url: http://localhost:8080
+}


### PR DESCRIPTION
This PR adds a patch endpoint to the API, allowing the `Title` and `Price` fields to be updated for a given item.

The Bruno collection has also been added in this PR, to allow for testing and to document the expected usage of the API endpoints.