### PR TITLE
RPM packaging for TUI

### DIFF
--- a/tui/.goreleaser.yaml
+++ b/tui/.goreleaser.yaml
@@ -1,0 +1,19 @@
+---
+project_name: example
+builds:
+  - env: [CGO_ENABLED=0]
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+nfpms:
+- maintainer: Charlie Stubbs <contact@charlierstubbs.com>
+  description: A simple TUI to interact with a shop API.
+  homepage: https://github.com/charlie-will-software/shop-tui
+  license: GPL3
+  formats:
+  - deb
+  - rpm
+  - apk

--- a/tui/README.md
+++ b/tui/README.md
@@ -1,0 +1,22 @@
+# Shop TUI
+
+## Packaging
+
+### RPM
+
+#### Requirements
+
+```bash
+dnf install -y rpmdevtools rpmlint
+```
+
+#### Build
+
+```bash
+rpmdev-setuptree
+cp <REPO_PATH>/tui/shop-tui.spec ./rpmbuild/SPECS/
+spectool -gR ~/rpmbuild/SPECS/shop-tui.spec
+rpmbuild -ba ~/rpmbuild/SPECS/shop-tui.spec
+```
+
+The `.rpm` will then be available under `~/rpmbuild/RPMS/x86_64/`

--- a/tui/shop-tui.spec
+++ b/tui/shop-tui.spec
@@ -1,0 +1,31 @@
+Name:           shop-tui
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        A Terminal User Interface (TUI) for the Shop-TUI project.
+
+BuildArch:      x86_64
+
+License:        GPL3
+URL:            https://github.com/charlie-will-software/shop-tui
+Source0:        %{url}/releases/download/v%{version}/%{name}_%{version}_linux_amd64.tar.gz
+
+%description
+Your package description.
+
+%prep
+tar -xzf %{SOURCE0} -C .
+
+%build
+# Nothing to build
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_bindir}
+ls .
+cp %{name} %{buildroot}/%{_bindir}
+
+%files
+%{_bindir}/%{name}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
Turns out goreleaser can use [nfpm](https://github.com/goreleaser/nfpm) to package up the binaries it creates. I decided to keep the `.spec` file anyways, since I learned some things creating it.